### PR TITLE
Display GDB TUI in frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,10 @@
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "swr": "^1.3.0",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "xterm": "^5.0.0",
+        "xterm-addon-attach": "^0.7.0",
+        "xterm-addon-fit": "^0.6.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -16730,6 +16733,27 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/xterm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.0.0.tgz",
+      "integrity": "sha512-tmVsKzZovAYNDIaUinfz+VDclraQpPUnAME+JawosgWRMphInDded/PuY0xmU5dOhyeYZsI0nz5yd8dPYsdLTA=="
+    },
+    "node_modules/xterm-addon-attach": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.7.0.tgz",
+      "integrity": "sha512-Yh3Kvq2e28onjnmGizQKZwlRMp9gmuZEHVX0BVZbo463YSjkqfhQS3T2wMLuO+j8AokccXsMa1z0bH1/+MMYuQ==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
+      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -28664,6 +28688,23 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "xterm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.0.0.tgz",
+      "integrity": "sha512-tmVsKzZovAYNDIaUinfz+VDclraQpPUnAME+JawosgWRMphInDded/PuY0xmU5dOhyeYZsI0nz5yd8dPYsdLTA=="
+    },
+    "xterm-addon-attach": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.7.0.tgz",
+      "integrity": "sha512-Yh3Kvq2e28onjnmGizQKZwlRMp9gmuZEHVX0BVZbo463YSjkqfhQS3T2wMLuO+j8AokccXsMa1z0bH1/+MMYuQ==",
+      "requires": {}
+    },
+    "xterm-addon-fit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz",
+      "integrity": "sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==",
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,10 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "swr": "^1.3.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "xterm": "^5.0.0",
+    "xterm-addon-attach": "^0.7.0",
+    "xterm-addon-fit": "^0.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,10 +1,20 @@
+body {
+  background-color: #282c34;
+}
+
 .App {
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.terminal {
+  height: 70vh;
 }
 
 .command-form {
-  background-color: #282c34;
-  min-height: 100vh;
+  text-align: center;
+  height: 30vh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,12 @@
 import "./App.css";
+import GDBTerminal from "./Terminal";
 import ThreadPicker from "./ThreadPicker";
 
 function App() {
   return (
     <div className="App">
+      <GDBTerminal class="terminal" />
+
       <form className="command-form" action="/api/output" method="POST">
         <ThreadPicker />
         <label>

--- a/frontend/src/Terminal.jsx
+++ b/frontend/src/Terminal.jsx
@@ -1,0 +1,68 @@
+import "./Terminal.css";
+import "../node_modules/xterm/css/xterm.css";
+import { useEffect, useRef } from "react";
+import { Terminal } from "xterm";
+import { AttachAddon } from "xterm-addon-attach";
+import { FitAddon } from "xterm-addon-fit";
+
+export default function GDBTerminal() {
+  const termDiv = useRef(null);
+  // eslint-disable-next-line no-unused-vars
+  // const [term, _setTerm] = useState(new Terminal());
+  // // eslint-disable-next-line no-unused-vars
+  // const [fitAddon, _setFitAddon] = useState(new FitAddon());
+  // const [sock, setSock] = useState(null);
+
+  // useEffect(() => {
+  //   term.loadAddon(fitAddon);
+  // }, [term, fitAddon]);
+
+  // useLayoutEffect(() => {
+  //   // NOTE: May lead to race condition when addon is loaded?
+  //   function sizeChanged() {
+  //     fitAddon.fit();
+  //     if (sock !== null) {
+  //       sock.
+  //     }
+  //   }
+  //   window.addEventListener("resize", sizeChanged);
+  //   sizeChanged();
+  //   return () => window.removeEventListener("resize", sizeChanged);
+  // }, [fitAddon]);
+
+  useEffect(() => {
+    const term = new Terminal()
+    const fitAddon = new FitAddon();
+    term.open(document.getElementById("terminal"));
+
+    fitAddon.fit();
+
+    // To protect against race condition where we clean up before getting the websocket
+    let disposed = false;
+
+    async function attachSocket() {
+      // Find the port to use from the server
+      const res = await fetch("/api/websocket");
+      const data = await res.json();
+      const port = data.port;
+
+      if (!disposed) {
+        console.log("Trying to connect");
+        // setSock(new WebSocket(`ws://localhost:${port}`))
+        const sock =new WebSocket(`ws://localhost:${port}`)
+        const attachAddon = new AttachAddon(sock);
+
+        term.loadAddon(attachAddon);
+      }
+    }
+
+    attachSocket();
+
+    return () => {
+      disposed = true;
+      term.dispose();
+    };
+  }, []);
+
+  return <div id="terminal" ref={termDiv}></div>;
+}

--- a/gdb_websocket.py
+++ b/gdb_websocket.py
@@ -1,0 +1,117 @@
+import io
+import os
+import pty
+import signal
+from typing import cast
+
+from pygdbmi.gdbcontroller import DEFAULT_GDB_LAUNCH_COMMAND
+from pygdbmi.constants import DEFAULT_GDB_TIMEOUT_SEC
+from pygdbmi.IoManager import IoManager
+
+
+class GdbController:
+    gdb: IoManager
+    gdb_pid: int
+    using_mi: bool
+
+    # stdin/out that the gdb instance is using (really just a pseudoterminal)
+    # Writing and reading may seem flipped, but remember we are observing the pty
+    tui_stdin: io.BufferedWriter
+    tui_stdout: io.BufferedReader
+
+    # # Pty information for console input/output (os opposed to MI)
+    # tui_pty_master: int
+    # tui_pty_slave: int
+
+    def __init__(self) -> None:
+        self.tui_pty_master, self.tui_pty_slave = pty.openpty()
+        gdb_tui_tty_name = os.ttyname(self.tui_pty_slave)
+
+        self.tui_stdin = os.fdopen(self.tui_pty_master, mode="wb")
+        self.tui_stdout = os.fdopen(self.tui_pty_master, mode="rb")
+
+        startup_commands = [
+            f"new-ui console {gdb_tui_tty_name}",
+            "set pagination off",
+            "set debuginfod enabled on",
+        ]
+        startup_commands_str = [f"-iex={c}" for c in startup_commands]
+        command = [*DEFAULT_GDB_LAUNCH_COMMAND, *startup_commands_str]
+        command = DEFAULT_GDB_LAUNCH_COMMAND
+        print(command)
+
+        pid, termfd = pty.fork()
+
+        if pid == 0:
+            # Child: start gdb
+            os.execvp(command[0], command)
+
+        # Parent: record the info
+        self.gdb_pid = pid
+
+        # Create in/out off of pty and IoManager to interact w/ gdb through MI
+        self.gdb = IoManager(
+            os.fdopen(termfd, mode="wb"),
+            os.fdopen(termfd, mode="rb"),
+            None,
+        )
+
+        self.using_mi = True
+
+    def terminate(self):
+        """
+        Kill the GDB process we're controlling and ensure that future calls to read and
+        write will fail.
+        """
+        if self.gdb is not None:
+            os.kill(self.gdb_pid, signal.SIGKILL)
+            self.gdb = None  # type: ignore
+            self.gdb_pid = -1
+            self.mi_stdin = None  # type: ignore
+            self.mi_stdout = None  # type: ignore
+
+    def set_mi(self, using_mi: bool) -> None:
+        """Set whether we are using GDB's MI to influence what read and write do."""
+        self.using_mi = using_mi
+
+    def read(
+        self, timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC, raise_error_on_timeout=True
+    ):
+        """
+        If we are using MI right now, get and parse GDB response. Otherwise, read
+        bytes directly from the pty connected to the gdb instance. See
+        `IoManager.get_gdb_response()` for details about flags
+        """
+        if self.using_mi:
+            return self.gdb.get_gdb_response(timeout_sec, raise_error_on_timeout)
+        return self.tui_stdout.read()
+
+    def write(
+        self,
+        data: str | list[str] | bytes,
+        timeout_sec=DEFAULT_GDB_TIMEOUT_SEC,
+        raise_error_on_timeout: bool = True,
+        read_response: bool = True,
+    ):
+        """
+        If we are using MI right now, write using pygdmi. Otherwise, write
+        bytes directly to the pty connected to the gdb instance. See
+        `IoManager.write()` for details about flags
+        """
+        if self.using_mi:
+            mi_cmd_to_write = cast(str | list[str], data)
+            print(mi_cmd_to_write)
+            return self.gdb.write(
+                mi_cmd_to_write,
+                timeout_sec,
+                raise_error_on_timeout,
+                read_response,
+            )
+        # It's only a list of commands if we're using MI, but we're not
+        data = cast(bytes, data)
+        return self.tui_stdin.write(data)
+
+
+# async def watch_gdb(gdb: IoManager) -> None:
+#     while True:
+#         gdb._buffer_incomplete_responses

--- a/gdb_websocket.py
+++ b/gdb_websocket.py
@@ -2,6 +2,7 @@ import io
 import os
 import pty
 import signal
+import subprocess
 from typing import cast
 
 from pygdbmi.gdbcontroller import DEFAULT_GDB_LAUNCH_COMMAND
@@ -11,8 +12,7 @@ from pygdbmi.IoManager import IoManager
 
 class GdbController:
     gdb: IoManager
-    gdb_pid: int
-    using_mi: bool
+    gdb_process: subprocess.Popen
 
     # stdin/out that the gdb instance is using (really just a pseudoterminal)
     # Writing and reading may seem flipped, but remember we are observing the pty
@@ -38,51 +38,37 @@ class GdbController:
         startup_commands_str = [f"-iex={c}" for c in startup_commands]
         command = [*DEFAULT_GDB_LAUNCH_COMMAND, *startup_commands_str]
         command = DEFAULT_GDB_LAUNCH_COMMAND
-        print(command)
 
-        pid, termfd = pty.fork()
-
-        if pid == 0:
-            # Child: start gdb
-            os.execvp(command[0], command)
-
-        # Parent: record the info
-        self.gdb_pid = pid
+        self.gdb_process = subprocess.Popen(
+            command,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
 
         # Create in/out off of pty and IoManager to interact w/ gdb through MI
         self.gdb = IoManager(
-            os.fdopen(termfd, mode="wb"),
-            os.fdopen(termfd, mode="rb"),
-            None,
+            self.gdb_process.stdin,  # type: ignore
+            self.gdb_process.stdout,  # type: ignore
+            self.gdb_process.stderr,  # type: ignore
         )
 
         self.using_mi = True
 
-    def terminate(self):
-        """
-        Kill the GDB process we're controlling and ensure that future calls to read and
-        write will fail.
-        """
-        if self.gdb is not None:
-            os.kill(self.gdb_pid, signal.SIGKILL)
-            self.gdb = None  # type: ignore
-            self.gdb_pid = -1
-            self.mi_stdin = None  # type: ignore
-            self.mi_stdout = None  # type: ignore
-
-    def set_mi(self, using_mi: bool) -> None:
-        """Set whether we are using GDB's MI to influence what read and write do."""
-        self.using_mi = using_mi
-
     def read(
-        self, timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC, raise_error_on_timeout=True
+        self,
+        timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
+        raise_error_on_timeout=True,
+        using_mi: bool = True,
     ):
         """
         If we are using MI right now, get and parse GDB response. Otherwise, read
         bytes directly from the pty connected to the gdb instance. See
         `IoManager.get_gdb_response()` for details about flags
         """
-        if self.using_mi:
+        if using_mi:
             return self.gdb.get_gdb_response(timeout_sec, raise_error_on_timeout)
         return self.tui_stdout.read()
 
@@ -92,13 +78,14 @@ class GdbController:
         timeout_sec=DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
         read_response: bool = True,
+        using_mi: bool = True,
     ):
         """
         If we are using MI right now, write using pygdmi. Otherwise, write
         bytes directly to the pty connected to the gdb instance. See
         `IoManager.write()` for details about flags
         """
-        if self.using_mi:
+        if using_mi:
             mi_cmd_to_write = cast(str | list[str], data)
             print(mi_cmd_to_write)
             return self.gdb.write(


### PR DESCRIPTION
Adds support for displaying the GDB TUI in the frontend via the `GDBTerminal` component. Also changes the `GDBController` in the backend to control two versions of the same GDB instance: MI via pipes (same as pygdmi) and the TUI via pseudoterminals (`pty` package).